### PR TITLE
chore(deps): bump neo4j.version from 4.4.0 to 4.4.1 in /boot-data-neo4j

### DIFF
--- a/boot-data-neo4j/pom.xml
+++ b/boot-data-neo4j/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <neo4j.version>4.4.0</neo4j.version>
+        <neo4j.version>4.4.1</neo4j.version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     </properties>


### PR DESCRIPTION
Bumps `neo4j.version` from 4.4.0 to 4.4.1.

Updates `neo4j-java-driver-slim` from 4.4.0 to 4.4.1

Updates `neo4j-harness` from 4.4.0 to 4.4.1
- [Release notes](https://github.com/neo4j/neo4j/releases)
- [Commits](https://github.com/neo4j/neo4j/commits)

---
updated-dependencies:
- dependency-name: org.neo4j.driver:neo4j-java-driver-slim
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.neo4j.test:neo4j-harness
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>