### PR TITLE
Move blocking UUID generation to boundedElastic thread

### DIFF
--- a/boot-data-redis/src/main/java/com/example/demo/DataInitializer.java
+++ b/boot-data-redis/src/main/java/com/example/demo/DataInitializer.java
@@ -1,10 +1,13 @@
 package com.example.demo;
 
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 @Component
 @Slf4j
@@ -30,16 +33,13 @@ class DataInitializer implements CommandLineRunner {
                       return this.posts.save(
                           Post.builder().id(id).title(title).content("content of " + title)
                               .build());
-                    }
-                )
-                .subscribeOn(Schedulers.boundedElastic())
-        )
+                    })
+                .subscribeOn(Schedulers.boundedElastic()))
         .log()
         .subscribe(
             null,
             null,
-            () -> log.info("done initialization...")
-        );
+            () -> log.info("done initialization..."));
 
   }
 

--- a/boot-data-redis/src/main/java/com/example/demo/DataInitializer.java
+++ b/boot-data-redis/src/main/java/com/example/demo/DataInitializer.java
@@ -32,6 +32,7 @@ class DataInitializer implements CommandLineRunner {
                               .build());
                     }
                 )
+                .subscribeOn(Schedulers.boundedElastic())
         )
         .log()
         .subscribe(

--- a/boot-data-redis/src/main/java/com/example/demo/DemoApplication.java
+++ b/boot-data-redis/src/main/java/com/example/demo/DemoApplication.java
@@ -6,33 +6,16 @@ import static org.springframework.web.reactive.function.server.RequestPredicates
 import static org.springframework.web.reactive.function.server.RequestPredicates.PUT;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
-import java.net.URI;
-import java.time.LocalDateTime;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
-import org.springframework.data.redis.core.ReactiveRedisOperations;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.RouterFunction;
-import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 @SpringBootApplication
 public class DemoApplication {

--- a/boot-kotlin/src/test/kotlin/com/example/demo/PostControllerTests.kt
+++ b/boot-kotlin/src/test/kotlin/com/example/demo/PostControllerTests.kt
@@ -4,7 +4,6 @@ package com.example.demo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.*
-import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration
@@ -13,10 +12,12 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.util.*
 
 @WebFluxTest(
-        controllers = [PostController::class],
-        excludeAutoConfiguration = [ReactiveUserDetailsServiceAutoConfiguration::class, ReactiveSecurityAutoConfiguration::class]
+    controllers = [PostController::class],
+    excludeAutoConfiguration = [ReactiveUserDetailsServiceAutoConfiguration::class, ReactiveSecurityAutoConfiguration::class]
 )
 class PostControllerTests {
 
@@ -35,16 +36,33 @@ class PostControllerTests {
     @Test
     fun `get all posts`() {
         val postsFlux = Flux.just("Post one", "Post two")
-                .map {
-                    Post(title = it, content = "content of $it")
-                }
+            .map {
+                Post(title = it, content = "content of $it")
+            }
         given(posts.findAll()).willReturn(postsFlux)
         client.get()
-                .uri("/posts")
-                .exchange()
-                .expectStatus()
-                .isOk
+            .uri("/posts")
+            .exchange()
+            .expectStatus()
+            .isOk
         verify(posts, times(1)).findAll()
+        verifyNoMoreInteractions(this.posts)
+    }
+
+    @Test
+    fun `get post by id`() {
+        val id = UUID.randomUUID().toString()
+        val postMono = Mono
+            .just(
+                Post(id = id, title = "test", content = "content of test")
+            )
+        given(posts.findById(any(String::class.java))).willReturn(postMono)
+        client.get()
+            .uri("/posts/$id")
+            .exchange()
+            .expectStatus()
+            .isOk
+        verify(posts, times(1)).findById(anyString())
         verifyNoMoreInteractions(this.posts)
     }
 


### PR DESCRIPTION
Hi! :) 

Thank you for for the effort for this handy project.

We found a blocking call in DataInitializer class via Blockhound:
<img width="1262" alt="srs1-blocking" src="https://github.com/hantsy/spring-reactive-sample/assets/56495631/b3b11acf-40c9-40ed-bfda-083a31b7c2ea">

This PR fixes the blocking code. We re-ran the tests and also compared performance (CPU usage) before and after the fix:

**Before**
<img width="1360" alt="srs1-cpu-before" src="https://github.com/hantsy/spring-reactive-sample/assets/56495631/e0291dd0-3e85-453d-8f3e-cbfbd23bac09">


**After**
<img width="1345" alt="srs1-cpu-after" src="https://github.com/hantsy/spring-reactive-sample/assets/56495631/d7e82c5b-42c0-4d1e-a79f-02112ed2ef5c">
