### PR TITLE
Execute blocking UUID generation on executor thread

### DIFF
--- a/websocket/src/main/java/com/example/demo/MessagetHandler.java
+++ b/websocket/src/main/java/com/example/demo/MessagetHandler.java
@@ -38,7 +38,7 @@ public class MessagetHandler implements WebSocketHandler {
         var receiveMono = session.receive()
                 .map(WebSocketMessage::getPayloadAsText)
                 .map(this::readIncomingMessage)
-                .map(req -> Mono.fromCallable(() ->
+                .flatMap(req -> Mono.fromCallable(() ->
                                 Message.builder().id(UUID.randomUUID()).body(req.message()).sentAt(LocalDateTime.now()).build()))
                 .log("server receiving::")
 //                .subscribe(
@@ -47,7 +47,7 @@ public class MessagetHandler implements WebSocketHandler {
 //                );
                 .doOnNext(data -> {
                     executor.execute(() -> {
-                        sinks.emitNext(data.block(), Sinks.EmitFailureHandler.FAIL_FAST);
+                        sinks.emitNext(data, Sinks.EmitFailureHandler.FAIL_FAST);
                     });
                 })
                 .doOnError(error -> sinks.emitError(error, Sinks.EmitFailureHandler.FAIL_FAST))


### PR DESCRIPTION
Hi! 🙂 

Thank you for this handy project. You did a great job in ensuring the reactive pipeline indeed remains reactive end to end to show case the full efficacy of reactive programming.

There is one blocking call , however, in `MessageHandler` class in `websocket` module, as detected by BlockHound:

<img width="813" alt="srs2-blocking" src="https://github.com/hantsy/spring-reactive-sample/assets/56495631/bfcacaf3-c769-47f9-a113-42f94a8dbb76">

This PR fixes the blocking code. We re-ran the tests and also compared the performance (in terms of main thread latency) before and after the fix:

**Before**
<img width="1275" alt="sr2-latency-before" src="https://github.com/hantsy/spring-reactive-sample/assets/56495631/5001e029-e862-4192-a032-e2933ee43be3">


**After**
<img width="1155" alt="sr2-latency-after" src="https://github.com/hantsy/spring-reactive-sample/assets/56495631/bf0d9135-6f6d-45b7-80dc-3a7ce666bc70">

