### PR TITLE
fix: Corrected typo in 'Webfitler' to 'Webfilter'

### DIFF
--- a/docs/web/web-filter.md
+++ b/docs/web/web-filter.md
@@ -35,7 +35,7 @@ public class SecurityWebFilter implements WebFilter{
 }
 ```
 
-> NOTE: In a Spring application, I would like use Spring Security to handle security considerations. Here I just use this as an example of `WebFitler`.
+> NOTE: In a Spring application, I would like use Spring Security to handle security considerations. Here I just use this as an example of `WebFilter`.
 > 
 
 


### PR DESCRIPTION
The commit fixes a minor typo in the 'web-filter.md' file, where 'Webfitler' was corrected to 'Webfilter' for accuracy and clarity.