### PR TITLE
feat: using sping boot OOTB testcontainers

### DIFF
--- a/boot-data-cassandra/pom.xml
+++ b/boot-data-cassandra/pom.xml
@@ -20,7 +20,6 @@
 
     <properties>
         <java.version>17</java.version>
-		<testcontainers.version>1.19.1</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -60,17 +59,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/boot-data-couchbase/pom.xml
+++ b/boot-data-couchbase/pom.xml
@@ -20,7 +20,6 @@
 
     <properties>
         <java.version>17</java.version>
-		<testcontainers.version>1.19.1</testcontainers.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
     </properties>
 
@@ -60,17 +59,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/boot-data-mongo-tailable/pom.xml
+++ b/boot-data-mongo-tailable/pom.xml
@@ -15,7 +15,6 @@
     <description>Spring Data Mongo reactive Tailable example</description>
     <properties>
         <java.version>17</java.version>
-        <testcontainers.version>1.19.1</testcontainers.version>
     </properties>
     <dependencies>
         <dependency>
@@ -53,17 +52,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/boot-data-mongo/pom.xml
+++ b/boot-data-mongo/pom.xml
@@ -20,7 +20,6 @@
 
     <properties>
         <java.version>17</java.version>
-        <testcontainers.version>1.19.1</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -59,17 +58,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/boot-mongo/pom.xml
+++ b/boot-mongo/pom.xml
@@ -20,7 +20,6 @@
 
     <properties>
         <java.version>17</java.version>
-        <testcontainers.version>1.19.1</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -63,17 +62,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/boot-neo4j/pom.xml
+++ b/boot-neo4j/pom.xml
@@ -16,7 +16,6 @@
 
     <properties>
         <java.version>17</java.version>
-        <testcontainers.version>1.19.1</testcontainers.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
     </properties>
 
@@ -55,18 +54,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/boot-redis/pom.xml
+++ b/boot-redis/pom.xml
@@ -20,19 +20,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <testcontainers.version>1.19.1</testcontainers.version>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/data-neo4j/pom.xml
+++ b/data-neo4j/pom.xml
@@ -20,7 +20,6 @@
         <maven.compiler.release>17</maven.compiler.release>
         <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
-        <testcontainers.version>1.19.1</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -104,18 +103,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
From spring boot 3.1.0, SB is supporting testcontainers in spring boot dependencies. so we can re use it. Hence removing all explict dependencies. 