### PR TITLE
test: use versioned MongoDB Testcontainers image

### DIFF
--- a/boot-data-mongo/src/test/java/com/example/demo/MongodbContainerInitializer.java
+++ b/boot-data-mongo/src/test/java/com/example/demo/MongodbContainerInitializer.java
@@ -12,7 +12,7 @@ import java.time.Duration;
 @Slf4j
 class MongodbContainerInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
     public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-        var container = new MongoDBContainer("mongo")
+        var container = new MongoDBContainer("mongo:8.0")
                 .withStartupTimeout(Duration.ofSeconds(60));
         container.start();
 

--- a/boot-data-mongo/src/test/java/com/example/demo/PostRepositoryWithDynamicPropertiesTest.java
+++ b/boot-data-mongo/src/test/java/com/example/demo/PostRepositoryWithDynamicPropertiesTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PostRepositoryWithDynamicPropertiesTest {
 
     @Container
-    static MongoDBContainer container = new MongoDBContainer("mongo")
+    static MongoDBContainer container = new MongoDBContainer("mongo:8.0")
             .withStartupTimeout(Duration.ofSeconds(60));
 
     @DynamicPropertySource

--- a/boot-exception-handler/src/test/java/com/example/demo/ContainerConfig.java
+++ b/boot-exception-handler/src/test/java/com/example/demo/ContainerConfig.java
@@ -4,13 +4,16 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.testcontainers.mongodb.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
 public class ContainerConfig {
 
+	private static final DockerImageName MONGO_IMAGE = DockerImageName.parse("mongo:8.0");
+
     @Bean
     @ServiceConnection
     MongoDBContainer mongoDBContainer() {
-        return new MongoDBContainer("mongo:latest");
+    	return new MongoDBContainer(MONGO_IMAGE);
     }
 }

--- a/boot-kotlin-co-dsl/src/test/kotlin/com/example/demo/TestcontainersConfiguration.kt
+++ b/boot-kotlin-co-dsl/src/test/kotlin/com/example/demo/TestcontainersConfiguration.kt
@@ -12,7 +12,7 @@ class TestcontainersConfiguration {
     @Bean
     @ServiceConnection
     fun mongoDbContainer(): MongoDBContainer {
-        return MongoDBContainer(DockerImageName.parse("mongo:latest"))
+        return MongoDBContainer(DockerImageName.parse("mongo:8.0"))
     }
 
 }

--- a/boot-kotlin-co/src/test/kotlin/com/example/demo/TestcontainersConfiguration.kt
+++ b/boot-kotlin-co/src/test/kotlin/com/example/demo/TestcontainersConfiguration.kt
@@ -12,7 +12,7 @@ class TestcontainersConfiguration {
     @Bean
     @ServiceConnection
     fun mongoDbContainer(): MongoDBContainer {
-        return MongoDBContainer(DockerImageName.parse("mongo:latest"))
+        return MongoDBContainer(DockerImageName.parse("mongo:8.0"))
     }
 
 }

--- a/kotlin-co/src/test/kotlin/com/example/test/repository/MongoContextInitializer.kt
+++ b/kotlin-co/src/test/kotlin/com/example/test/repository/MongoContextInitializer.kt
@@ -13,7 +13,7 @@ import java.util.Map
 class MongoContextInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
     companion object {
         private val log = LoggerFactory.getLogger(MongoContextInitializer::class.java)
-        private val container = MongoDBContainer("mongo")
+        private val container = MongoDBContainer("mongo:8.0")
     }
 
     override fun initialize(applicationContext: ConfigurableApplicationContext) {


### PR DESCRIPTION
## Summary

Use a versioned MongoDB Docker image for the `boot-exception-handler` Testcontainers configuration.

## Why

The test configuration currently uses `mongo:latest`, which is a moving target and can change unexpectedly over time. Using a versioned image makes the integration test setup more reproducible and predictable.

Future MongoDB upgrades can still be done intentionally by updating the image tag and running the test suite.

## Testing

```bash
cd boot-exception-handler
./mvnw clean test